### PR TITLE
Fix loading design by URL

### DIFF
--- a/src/api/kitePaint/__unit__/getDesign.test.js
+++ b/src/api/kitePaint/__unit__/getDesign.test.js
@@ -11,14 +11,10 @@ describe("#getDesign", () => {
     };
   });
   it("makes the relevant request", async () => {
-    expect.assertions(2);
     await Api.getDesign("abc").catch(() => {});
-    expect(Api.axiosInstance.get.mock.calls[0][0]).toEqual("/designs.php");
-    expect(Api.axiosInstance.get.mock.calls[0][1]).toEqual({
-      params: {
-        id: "abc"
-      }
-    });
+    expect(Api.axiosInstance.get.mock.calls[0][0]).toEqual(
+      "/designs.php?filter%5Bid%5D=abc"
+    );
   });
   it("does not make identical requests when they have been cached", async () => {
     expect.assertions(1);

--- a/src/api/kitePaint/getDesign.js
+++ b/src/api/kitePaint/getDesign.js
@@ -1,3 +1,4 @@
+import Qs from "qs";
 import Design from "../../models/Design";
 import { error } from "../../theme/Alert";
 
@@ -15,11 +16,15 @@ export default async function getDesign(id, useCache = true) {
       return cache;
     }
   }
-  const response = await this.axiosInstance.get("/designs.php", {
-    params: {
+  const requestData = {
+    filter: {
       id
     }
-  });
+  };
+  const requestString = Qs.stringify(requestData);
+  const response = await this.axiosInstance.get(
+    `/designs.php?${requestString}`
+  );
 
   // Handle invalid responses
   if (!response.data || !response.data.length) {


### PR DESCRIPTION
Requests to `/designs.php?id=[id]` were getting a 500 for some reason.

Changing the request pattern to `/designs.php?filter[id]=[id]` to match the typical request for multiple designs seems to be working fine. So, changed the request pattern to match.